### PR TITLE
Make RTL layout permanent

### DIFF
--- a/nfpApp/src/app/layouts/theme-customizer.html
+++ b/nfpApp/src/app/layouts/theme-customizer.html
@@ -126,28 +126,7 @@
                         </button>
                     </div>
                 </div>
-                <div class="mb-3 rounded-md border border-dashed border-[#e0e6ed] p-3 dark:border-[#1b2e4b]">
-                    <h5 class="mb-1 text-base leading-none dark:text-white">Direction</h5>
-                    <p class="text-xs text-white-dark">Select the direction for your app.</p>
-                    <div class="mt-3 flex gap-2">
-                        <button
-                            type="button"
-                            class="btn flex-auto"
-                            [ngClass]="[store.rtlClass === 'ltr' ? 'btn-primary' : 'btn-outline-primary']"
-                            (click)="storeData.dispatch({ type: 'toggleRTL', payload: 'ltr'});reloadRoute();"
-                        >
-                            LTR
-                        </button>
-                        <button
-                            type="button"
-                            class="btn flex-auto"
-                            [ngClass]="[store.rtlClass === 'rtl' ? 'btn-primary' : 'btn-outline-primary']"
-                            (click)="storeData.dispatch({ type: 'toggleRTL', payload: 'rtl'});reloadRoute();"
-                        >
-                            RTL
-                        </button>
-                    </div>
-                </div>
+                <!-- RTL is enforced in the application. Direction selector removed. -->
 
                 <div class="mb-3 rounded-md border border-dashed border-[#e0e6ed] p-3 dark:border-[#1b2e4b]">
                     <h5 class="mb-1 text-base leading-none dark:text-white">Navbar Type</h5>

--- a/nfpApp/src/app/service/app.service.ts
+++ b/nfpApp/src/app/service/app.service.ts
@@ -39,8 +39,9 @@ export class AppService {
             this.toggleLanguage(item);
         }
 
-        val = localStorage.getItem('rtlClass'); // rtl, ltr
-        val = val || $themeConfig.rtlClass;
+        // enforce RTL layout at all times
+        val = $themeConfig.rtlClass; // always rtl
+        localStorage.setItem('rtlClass', val);
         this.store.dispatch({ type: 'toggleRTL', payload: val });
 
         val = localStorage.getItem('animation'); // animate__fadeIn, animate__fadeInDown, animate__fadeInUp, animate__fadeInLeft, animate__fadeInRight, animate__slideInDown, animate__slideInLeft, animate__slideInRight, animate__zoomIn


### PR DESCRIPTION
## Summary
- enforce RTL mode by default in `AppService`
- remove direction selector from the theme customizer UI

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e741b2388324be42bc19f333bc85