### PR TITLE
Add authentication guard to product pages

### DIFF
--- a/PCH.NFP.API/Features/Product/ProductEndpoints.cs
+++ b/PCH.NFP.API/Features/Product/ProductEndpoints.cs
@@ -1,5 +1,6 @@
-﻿using Carter;
+using Carter;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 
 namespace PCH.NFP.API.Features;
 
@@ -7,10 +8,15 @@ public class ProductEndpoints : ICarterModule
 {
     public void AddRoutes(IEndpointRouteBuilder app)
     {
-        app.MapPost("/api/products", async (CreateProductCommand request, ISender sender) => Results.Ok(await sender.Send(request)));
-        app.MapGet("/api/products/{id}", async (long id, ISender sender) => Results.Ok(await sender.Send(new GetProductByIdQuery(id))));
-        app.MapGet("/api/products", async (int page, int pageSize, string? code, string? title, ISender sender) => Results.Ok(await sender.Send(new GetProductListQuery(page, pageSize, code, title))));
-        app.MapPut("/api/products", async (UpdateProductCommand request, ISender sender) => Results.Ok(await sender.Send(request)));
-        app.MapDelete("/api/products/{id}", async (long id, ISender sender) => Results.Ok(await sender.Send(new DeleteProductCommand(id))));
+        app.MapPost("/api/products", async (CreateProductCommand request, ISender sender) => Results.Ok(await sender.Send(request)))
+            .RequireAuthorization();
+        app.MapGet("/api/products/{id}", async (long id, ISender sender) => Results.Ok(await sender.Send(new GetProductByIdQuery(id))))
+            .RequireAuthorization();
+        app.MapGet("/api/products", async (int page, int pageSize, string? code, string? title, ISender sender) => Results.Ok(await sender.Send(new GetProductListQuery(page, pageSize, code, title))))
+            .RequireAuthorization();
+        app.MapPut("/api/products", async (UpdateProductCommand request, ISender sender) => Results.Ok(await sender.Send(request)))
+            .RequireAuthorization();
+        app.MapDelete("/api/products/{id}", async (long id, ISender sender) => Results.Ok(await sender.Send(new DeleteProductCommand(id))))
+            .RequireAuthorization();
     }
 }

--- a/nfpApp/src/app/app.module.ts
+++ b/nfpApp/src/app/app.module.ts
@@ -3,7 +3,7 @@ import { BrowserModule, Title } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { HttpBackend, HttpClient, HttpClientModule } from '@angular/common/http';
+import { HttpBackend, HttpClient, HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { RouterModule } from '@angular/router';
 
 //Routes
@@ -36,6 +36,10 @@ import { FooterComponent } from './layouts/footer';
 import { SidebarComponent } from './layouts/sidebar';
 import { ThemeCustomizerComponent } from './layouts/theme-customizer';
 
+import { AuthInterceptor } from './auth/auth.interceptor';
+import { AuthGuard } from './auth/auth.guard';
+import { AuthService } from './service/auth.service';
+
 @NgModule({
     imports: [
         RouterModule.forRoot(routes, { scrollPositionRestoration: 'enabled' }),
@@ -64,7 +68,12 @@ import { ThemeCustomizerComponent } from './layouts/theme-customizer';
         AuthLayout,
     ],
 
-    providers: [Title],
+    providers: [
+        Title,
+        AuthGuard,
+        AuthService,
+        { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+    ],
     bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/nfpApp/src/app/app.route.ts
+++ b/nfpApp/src/app/app.route.ts
@@ -2,11 +2,13 @@ import { Routes } from '@angular/router';
 
 import { AppLayout } from './layouts/app-layout';
 import { AuthLayout } from './layouts/auth-layout';
+import { AuthGuard } from './auth/auth.guard';
 
 export const routes: Routes = [
     {
         path: '',
         component: AppLayout,
+        canActivate: [AuthGuard],
         children: [
             { path: '', loadChildren: () => import('./products/product.module').then((d) => d.ProductModule) },
         ],

--- a/nfpApp/src/app/auth/auth.guard.ts
+++ b/nfpApp/src/app/auth/auth.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { AuthService } from '../service/auth.service';
+
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate {
+    constructor(private auth: AuthService, private router: Router) {}
+
+    canActivate(): boolean | UrlTree {
+        if (this.auth.isAuthenticated()) {
+            return true;
+        }
+        return this.router.createUrlTree(['/auth/cover-login']);
+    }
+}

--- a/nfpApp/src/app/auth/auth.interceptor.ts
+++ b/nfpApp/src/app/auth/auth.interceptor.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import {
+    HttpEvent,
+    HttpHandler,
+    HttpInterceptor,
+    HttpRequest,
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+        const token = localStorage.getItem('token');
+        if (token) {
+            req = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
+        }
+        return next.handle(req);
+    }
+}

--- a/nfpApp/src/app/auth/auth.module.ts
+++ b/nfpApp/src/app/auth/auth.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Routes, RouterModule } from '@angular/router';
+import { FormsModule } from '@angular/forms';
 
 // shared module
 import { SharedModule } from 'src/shared.module';
@@ -21,7 +22,7 @@ const routes: Routes = [
     { path: 'auth/cover-register', component: CoverRegisterComponent, data: { title: 'Cover Register' } },
 ];
 @NgModule({
-    imports: [RouterModule.forChild(routes), CommonModule, SharedModule.forRoot()],
+    imports: [RouterModule.forChild(routes), CommonModule, FormsModule, SharedModule.forRoot()],
     declarations: [
         CoverLockscreenComponent,
         CoverLoginComponent,

--- a/nfpApp/src/app/auth/cover-login.html
+++ b/nfpApp/src/app/auth/cover-login.html
@@ -81,11 +81,11 @@
                         <h1 class="text-3xl font-extrabold uppercase !leading-snug text-primary md:text-4xl">Sign in</h1>
                         <p class="text-base font-bold leading-normal text-white-dark">Enter your email and password to login</p>
                     </div>
-                    <form class="space-y-5 dark:text-white" (submit)="router.navigate(['/'])">
+                    <form class="space-y-5 dark:text-white" (ngSubmit)="login()" #f="ngForm">
                         <div>
-                            <label for="Email">Email</label>
+                            <label for="Email">Username</label>
                             <div class="relative text-white-dark">
-                                <input id="Email" type="email" placeholder="Enter Email" class="form-input ps-10 placeholder:text-white-dark" />
+                                <input id="Email" name="username" [(ngModel)]="username" type="text" placeholder="Enter Username" class="form-input ps-10 placeholder:text-white-dark" />
                                 <span class="absolute start-4 top-1/2 -translate-y-1/2">
                                     <icon-mail [fill]="true" />
                                 </span>
@@ -94,7 +94,7 @@
                         <div>
                             <label for="Password">Password</label>
                             <div class="relative text-white-dark">
-                                <input id="Password" type="password" placeholder="Enter Password" class="form-input ps-10 placeholder:text-white-dark" />
+                                <input id="Password" name="password" [(ngModel)]="password" type="password" placeholder="Enter Password" class="form-input ps-10 placeholder:text-white-dark" />
                                 <span class="absolute start-4 top-1/2 -translate-y-1/2">
                                     <icon-lock-dots [fill]="true" />
                                 </span>

--- a/nfpApp/src/app/auth/cover-login.ts
+++ b/nfpApp/src/app/auth/cover-login.ts
@@ -4,6 +4,7 @@ import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { AppService } from 'src/app/service/app.service';
+import { AuthService } from '../service/auth.service';
 
 @Component({
     templateUrl: './cover-login.html',
@@ -12,11 +13,14 @@ import { AppService } from 'src/app/service/app.service';
 export class CoverLoginComponent {
     store: any;
     currYear: number = new Date().getFullYear();
+    username = '';
+    password = '';
     constructor(
         public translate: TranslateService,
         public storeData: Store<any>,
         public router: Router,
         private appSetting: AppService,
+        private auth: AuthService,
     ) {
         this.initStore();
     }
@@ -37,5 +41,11 @@ export class CoverLoginComponent {
             this.storeData.dispatch({ type: 'toggleRTL', payload: 'ltr' });
         }
         window.location.reload();
+    }
+
+    login() {
+        this.auth.login(this.username, this.password).subscribe(() => {
+            this.router.navigate(['/products']);
+        });
     }
 }

--- a/nfpApp/src/app/service/auth.service.ts
+++ b/nfpApp/src/app/service/auth.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { Observable, tap } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+    private baseUrl = `${environment.apiUrl}/auth`;
+
+    constructor(private http: HttpClient, private router: Router) {}
+
+    login(username: string, password: string): Observable<any> {
+        return this.http
+            .post<any>(`${this.baseUrl}/login`, { username, password })
+            .pipe(
+                tap((res) => {
+                    const token = res?.data?.token;
+                    if (token) {
+                        localStorage.setItem('token', token);
+                    }
+                }),
+            );
+    }
+
+    logout() {
+        localStorage.removeItem('token');
+        this.router.navigate(['/auth/cover-login']);
+    }
+
+    isAuthenticated(): boolean {
+        return !!localStorage.getItem('token');
+    }
+}


### PR DESCRIPTION
## Summary
- add JWT authorization requirement to product API endpoints
- implement AuthService, AuthGuard and AuthInterceptor in Angular app
- update login form to submit credentials and store token
- protect product routes with AuthGuard
- register authentication modules and HTTP interceptor

## Testing
- `npm test` *(fails: ng not found)*
- `dotnet build PCH.NFP.API/PCH.NFP.API.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849eb75c38883249ad3f4d1c66a884f